### PR TITLE
Fix DialogTitle fontSize being overriden by h6 fontSize

### DIFF
--- a/src/components/DialogWithCloseButton/index.tsx
+++ b/src/components/DialogWithCloseButton/index.tsx
@@ -24,6 +24,7 @@ export const DialogWithCloseButton = ({
 						e.preventDefault();
 						e.stopPropagation();
 					}}
+					variant="inherit"
 				>
 					{title}
 					{onClose ? (


### PR DESCRIPTION
Fix DialogTitle fontSize being overriden by h6 fontSize

Change-type: patch