### PR TITLE
MUI Grid: Set the default value for `spacing` to be 2

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -536,6 +536,12 @@ export const theme = createTheme({
 				},
 			},
 		},
+		MuiGrid2: {
+			// We should only apply this spacing to Grid components with `container`
+			// But MUI does not currently support that for defaultProps
+			// See: https://github.com/mui/material-ui/issues/34812
+			defaultProps: { spacing: 2 },
+		},
 	},
 });
 


### PR DESCRIPTION
MUI Grid: Set the default value for `spacing` to be 2

Connects-to: https://github.com/balena-io/balena-ui/pull/6372
Change-type: patch