### PR TITLE
MUILinkWithTracking: Set `'_blank'` as the default value for `target`

### DIFF
--- a/src/components/MUILinkWithTracking/index.tsx
+++ b/src/components/MUILinkWithTracking/index.tsx
@@ -16,6 +16,7 @@ export const MUILinkWithTracking: React.FC<MUILinkWithTrackingProps> = ({
 	eventProperties,
 	children,
 	onClick,
+	target = '_blank',
 	...rest
 }) => {
 	const { state } = useAnalyticsContext();
@@ -37,7 +38,8 @@ export const MUILinkWithTracking: React.FC<MUILinkWithTrackingProps> = ({
 		<Link
 			{...rest}
 			onClick={handleClick}
-			rel={rest.target === '_blank' ? 'noreferrer' : undefined}
+			target={target}
+			rel={target === '_blank' ? 'noreferrer' : undefined}
 		>
 			{children}
 		</Link>


### PR DESCRIPTION
MUILinkWithTracking: Set `'_blank'` as the default value for `target`

Change-type: major