### PR TITLE
Remove icons-material export to improve bundle size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,5 @@ export {
 } from './contexts/AnalyticsContext';
 export * as Material from '@mui/material';
 export * as MaterialLab from '@mui/lab';
-export * as IconsMaterial from '@mui/icons-material';
 export { enqueueSnackbar, closeSnackbar } from 'notistack';
 export * as designTokens from '@balena/design-tokens';


### PR DESCRIPTION
Change-type: major


The library will be removed in https://github.com/balena-io-modules/ui-shared-components/pull/67, which will also replace internal iconMaterial use