### PR TITLE
Fix disabled styles for contained buttons

### DIFF
--- a/src/docs/30_mui_components/buttons.mdx
+++ b/src/docs/30_mui_components/buttons.mdx
@@ -3,7 +3,6 @@ import {
 	Box,
 	Button,
 	ThemeProvider,
-	ToggleButtonGroup,
 } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -40,7 +39,14 @@ import { LensToggle } from '../utils';
 		<Button variant="contained" color="success">Contained Success</Button>
 		<Button variant="contained" color="warning">Contained Warning</Button>
 		<Button variant="contained" color="error">Contained Danger</Button>
-		<Button variant="contained" disabled>Contained Disabled</Button>
+	</Box>
+	<Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+		<Button variant="contained" disabled color="primary">Contained Primary</Button>
+		<Button variant="contained" disabled color="secondary">Contained Secondary</Button>
+		<Button variant="contained" disabled color="info">Contained Info</Button>
+		<Button variant="contained" disabled color="success">Contained Success</Button>
+		<Button variant="contained" disabled color="warning">Contained Warning</Button>
+		<Button variant="contained" disabled color="error">Contained Danger</Button>
 	</Box>
 </ThemeProvider>
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -516,12 +516,23 @@ export const theme = createTheme({
 				},
 			],
 			styleOverrides: {
-				root: ({ theme }) => ({
+				root: ({ theme, ownerState }) => ({
 					borderRadius: '24px',
 					paddingLeft: '20px',
 					paddingRight: '20px',
 					fontSize: theme.typography.body1.fontSize,
 					textTransform: 'none',
+				}),
+				contained: ({ theme, ownerState }) => ({
+					'&.Mui-disabled': {
+						opacity: 0.5,
+						color: 'white',
+						backgroundColor: (
+							theme.palette[
+								ownerState.color as keyof typeof theme.palette
+							] as PaletteColor
+						).main,
+					},
 				}),
 				textPrimary: {
 					color: color.text.accent.value,


### PR DESCRIPTION
Fixes the "Start terminal session" button in the terminal.

Change-type: patch


### Before

![image](https://github.com/balena-io-modules/ui-shared-components/assets/1693766/5edb9c58-7fdb-4a8f-8cf0-34eb86b34e1f)

### After

![image](https://github.com/balena-io-modules/ui-shared-components/assets/1693766/998e740a-2b33-427a-b368-70c9454bdc92)
