### PR TITLE
Improve icon styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@balena/design-tokens": "^0.4.0",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@mui/icons-material": "^5.11.16",
         "@mui/lab": "^5.0.0-alpha.165",
         "@mui/material": "^5.12.0",
@@ -2932,6 +2934,52 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@googlemaps/js-api-loader": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
@@ -5530,9 +5578,9 @@
       }
     },
     "node_modules/@storybook/csf": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.2.tgz",
-      "integrity": "sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.3.tgz",
+      "integrity": "sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^2.19.0"
@@ -6875,9 +6923,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.19.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.22.tgz",
-      "integrity": "sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==",
+      "version": "18.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
+      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@balena/design-tokens": "^0.4.0",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/lab": "^5.0.0-alpha.165",
     "@mui/material": "^5.12.0",

--- a/src/components/DialogWithCloseButton/index.tsx
+++ b/src/components/DialogWithCloseButton/index.tsx
@@ -1,5 +1,6 @@
 import { Dialog, DialogProps, IconButton, DialogTitle } from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faClose } from '@fortawesome/free-solid-svg-icons/faClose';
 
 export type DialogWithCloseButtonProps = Omit<DialogProps, 'title'> & {
 	title: DialogProps['title'] | JSX.Element;
@@ -18,7 +19,7 @@ export const DialogWithCloseButton = ({
 					sx={{
 						display: 'flex',
 						justifyContent: 'space-between',
-						alignItems: 'flex-start',
+						alignItems: 'center',
 					}}
 					onClick={(e) => {
 						e.preventDefault();
@@ -29,15 +30,13 @@ export const DialogWithCloseButton = ({
 					{title}
 					{onClose ? (
 						<IconButton
+							edge="end"
 							aria-label="close"
 							onClick={(e) => {
 								onClose(e, 'backdropClick');
 							}}
-							sx={{
-								color: (theme) => theme.palette.grey[500],
-							}}
 						>
-							<CloseIcon />
+							<FontAwesomeIcon icon={faClose} />
 						</IconButton>
 					) : null}
 				</DialogTitle>

--- a/src/docs/30_mui_components/buttons.mdx
+++ b/src/docs/30_mui_components/buttons.mdx
@@ -5,11 +5,10 @@ import {
 	ThemeProvider,
 } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
-import DeleteIcon from '@mui/icons-material/Delete';
-import AlarmIcon from '@mui/icons-material/Alarm';
-import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
 import { theme } from '../../theme';
 import { LensToggle } from '../utils';
+import { faMagic, faTrashCan, faPlus, faDownload, faUpRightAndDownLeftFromCenter, faClose } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 <Meta title="Mui Components/Input/Button" />
 
@@ -78,24 +77,39 @@ import { LensToggle } from '../utils';
 	</Box>
 </ThemeProvider>
 
+## Button with icon
+
+<ThemeProvider theme={theme}>
+	<Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+		<Button color="primary" startIcon={<FontAwesomeIcon icon={faMagic} />}>Lorem ipsum</Button>
+		<Button variant="contained" color="primary" startIcon={<FontAwesomeIcon icon={faTrashCan} />}>Lorem ipsum</Button>
+		<Button variant="outlined" color="primary" endIcon={<FontAwesomeIcon icon={faPlus} />}>Lorem ipsum</Button>
+	</Box>
+</ThemeProvider>
+
 ## Icon Button
 
 <ThemeProvider theme={theme}>
 	<Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap' }}>
+		<IconButton aria-label="download">
+			<FontAwesomeIcon icon={faDownload} />
+		</IconButton>
 		<IconButton aria-label="delete">
-			<DeleteIcon />
+			<FontAwesomeIcon icon={faTrashCan} />
 		</IconButton>
-		<IconButton aria-label="delete" color="primary">
-			<DeleteIcon />
+		<IconButton aria-label="expand">
+			<FontAwesomeIcon icon={faUpRightAndDownLeftFromCenter} />
 		</IconButton>
-		<IconButton aria-label="delete" disabled color="primary">
-			<DeleteIcon />
+	</Box>
+	<Box sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap', mt: 2 }}>
+		<IconButton aria-label="close" size="small">
+			<FontAwesomeIcon icon={faClose} />
 		</IconButton>
-		<IconButton color="secondary" aria-label="add an alarm">
-			<AlarmIcon />
+		<IconButton aria-label="close" size="medium">
+			<FontAwesomeIcon icon={faClose} />
 		</IconButton>
-		<IconButton color="primary" aria-label="add to shopping cart">
-			<AddShoppingCartIcon />
+		<IconButton aria-label="close" size="large">
+			<FontAwesomeIcon icon={faClose} />
 		</IconButton>
 	</Box>
 </ThemeProvider>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -285,6 +285,9 @@ export const theme = createTheme({
 			900: color.palette.neutral['900'].value,
 		},
 		divider: color.border.subtle.value,
+		action: {
+			active: color.text.subtle.value,
+		},
 	},
 	spacing: [0, 4, 8, 16, 32, 64, 128],
 	components: {
@@ -325,6 +328,9 @@ export const theme = createTheme({
 					borderColor: color.border.danger.value,
 					backgroundColor: color.bg.danger.value,
 					color: color.text.danger.value,
+				},
+				action: {
+					paddingTop: 0,
 				},
 			},
 		},
@@ -595,6 +601,37 @@ export const theme = createTheme({
 				outlinedError: {
 					color: color.text.danger.value,
 					borderColor: color.border.danger.value,
+				},
+				startIcon: {
+					' > :nth-of-type(1)': {
+						fontSize: '14px',
+					},
+				},
+				endIcon: {
+					' > :nth-of-type(1)': {
+						fontSize: '14px',
+					},
+				},
+			},
+		},
+		MuiIconButton: {
+			styleOverrides: {
+				root: {
+					svg: {
+						width: '1em',
+					},
+				},
+				sizeSmall: {
+					padding: '10px',
+					fontSize: '12px',
+				},
+				sizeMedium: {
+					padding: '12px',
+					fontSize: '14px',
+				},
+				sizeLarge: {
+					padding: '14px',
+					fontSize: '16px',
 				},
 			},
 		},


### PR DESCRIPTION
Fix icon size too large (went from 14px to 20px after the buttons migration) and improve Icon Button styles.

Change-type: patch

### Before

![image](https://github.com/balena-io-modules/ui-shared-components/assets/1693766/d68353c5-85f1-46d3-8138-ee134107db75)

### After

![image](https://github.com/balena-io-modules/ui-shared-components/assets/1693766/369ffd39-699a-49d2-91d9-586a3b60c235)


### Before

![image](https://github.com/balena-io-modules/ui-shared-components/assets/1693766/bd0243c6-79ec-4f87-9262-2f7b28199747)

### After

![image](https://github.com/balena-io-modules/ui-shared-components/assets/1693766/4524fbd4-f0bf-498e-b80e-026ac72a0dd9)

