### PR TITLE
Fix text button styling

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -540,6 +540,18 @@ export const theme = createTheme({
 						).main,
 					},
 				}),
+				text: {
+					padding: 0,
+					minWidth: 'none',
+					userSelect: 'auto',
+					'&:hover,&:focus': {
+						background: 'none',
+						textDecoration: 'underline',
+					},
+					'.MuiTouchRipple-root': {
+						display: 'none',
+					},
+				},
 				textPrimary: {
 					color: color.text.accent.value,
 				},


### PR DESCRIPTION
Remove paddings around buttons with the variant `text`, disable the background color on hover and the ripple effect on active.

Change-type: patch