### PR TITLE
DownloadImageDialog: Drop support for device types with docker-image deployArtifact

### DIFF
--- a/src/components/DownloadImageDialog/ApplicationInstructions.tsx
+++ b/src/components/DownloadImageDialog/ApplicationInstructions.tsx
@@ -105,13 +105,8 @@ export const ApplicationInstructions = memo(
 			),
 		);
 
-		const hasConfigDownloadOnly =
-			deviceType.yocto?.deployArtifact === 'docker-image';
-
 		const finalInstructions = [
-			hasConfigDownloadOnly
-				? 'Use the form on the left to download a configuration for your new device.'
-				: 'Use the form on the left to configure and download balenaOS for your new device.',
+			'Use the form on the left to configure and download balenaOS for your new device.',
 			...interpolatedInstructions,
 			'Your device should appear in your application dashboard within a few minutes. Have fun!',
 		];

--- a/src/components/DownloadImageDialog/DownloadImageDialog.stories.tsx
+++ b/src/components/DownloadImageDialog/DownloadImageDialog.stories.tsx
@@ -68,14 +68,6 @@ const deviceTypes: any[] = [
 				],
 			},
 		],
-		yocto: {
-			machine: 'raspberrypi3-64',
-			image: 'balena-image',
-			fstype: 'balenaos-img',
-			version: 'yocto-honister',
-			deployArtifact: 'balena-image-raspberrypi3-64.balenaos-img',
-			compressed: true,
-		},
 		is_default_for__application: [
 			{
 				application_tag: [
@@ -212,14 +204,6 @@ const deviceTypes: any[] = [
 				],
 			},
 		],
-		yocto: {
-			machine: 'raspberrypi4-64',
-			image: 'balena-image',
-			fstype: 'balenaos-img',
-			version: 'yocto-honister',
-			deployArtifact: 'balena-image-raspberrypi4-64.balenaos-img',
-			compressed: true,
-		},
 		is_default_for__application: [
 			{
 				application_tag: [
@@ -354,14 +338,6 @@ const deviceTypes: any[] = [
 				],
 			},
 		],
-		yocto: {
-			machine: 'jetson-nano',
-			image: 'balena-image',
-			fstype: 'balenaos-img',
-			version: 'yocto-honister',
-			deployArtifact: 'balena-image-jetson-nano.balenaos-img',
-			compressed: true,
-		},
 		is_default_for__application: [
 			{
 				application_tag: [
@@ -483,14 +459,6 @@ const deviceTypes: any[] = [
 				],
 			},
 		],
-		yocto: {
-			machine: 'jetson-xavier-nx-devkit-emmc',
-			image: 'balena-image',
-			fstype: 'balenaos-img',
-			version: 'yocto-honister',
-			deployArtifact: 'balena-image-jetson-xavier-nx-devkit-emmc.balenaos-img',
-			compressed: true,
-		},
 		is_default_for__application: [
 			{
 				application_tag: [],
@@ -609,14 +577,6 @@ const initialDeviceType: any = {
 			],
 		},
 	],
-	yocto: {
-		machine: 'raspberrypi4-64',
-		image: 'balena-image',
-		fstype: 'balenaos-img',
-		version: 'yocto-honister',
-		deployArtifact: 'balena-image-raspberrypi4-64.balenaos-img',
-		compressed: true,
-	},
 	is_default_for__application: [
 		{
 			application_tag: [

--- a/src/components/DownloadImageDialog/index.tsx
+++ b/src/components/DownloadImageDialog/index.tsx
@@ -228,10 +228,6 @@ export const DownloadImageDialog: React.FC<DownloadImageDialogProps> = ({
 	);
 	const [isFetching, setIsFetching] = useState(isEmpty(osVersions));
 	const [downloadSize, setDownloadSize] = useState<string | null>(null);
-	const hasDockerImageDownload = useMemo(
-		() => formModel.deviceType?.yocto?.deployArtifact === 'docker-image',
-		[formModel.deviceType?.yocto?.deployArtifact],
-	);
 
 	const logoSrc = useMemo(
 		() =>
@@ -264,11 +260,8 @@ export const DownloadImageDialog: React.FC<DownloadImageDialogProps> = ({
 						<img width="20px" alt="etcher" src={etcherLogoBase64} /> Flash
 					</>
 				),
-				disabled: hasDockerImageDownload,
 				tooltip: {
-					title: hasDockerImageDownload
-						? 'This image is deployed to docker so you can only download its config'
-						: 'Etcher v1.7.2 or greater is required',
+					title: 'Etcher v1.7.2 or greater is required',
 					placement: 'top',
 				},
 			},
@@ -292,10 +285,6 @@ export const DownloadImageDialog: React.FC<DownloadImageDialogProps> = ({
 						{formModel.version && downloadSize ? ` (~${downloadSize})` : ''}
 					</>
 				),
-				disabled: hasDockerImageDownload,
-				tooltip: hasDockerImageDownload
-					? 'This image is deployed to docker so you can only download its config'
-					: '',
 			},
 		];
 
@@ -325,7 +314,6 @@ export const DownloadImageDialog: React.FC<DownloadImageDialogProps> = ({
 		downloadSize,
 		downloadUrl,
 		formModel,
-		hasDockerImageDownload,
 		dialogActions,
 		onDownloadStart,
 	]);

--- a/src/components/DownloadImageDialog/index.tsx
+++ b/src/components/DownloadImageDialog/index.tsx
@@ -229,13 +229,6 @@ export const DownloadImageDialog: React.FC<DownloadImageDialogProps> = ({
 	const [isFetching, setIsFetching] = useState(isEmpty(osVersions));
 	const [downloadSize, setDownloadSize] = useState<string | null>(null);
 
-	const logoSrc = useMemo(
-		() =>
-			formModel.deviceType?.logo ??
-			formModel.deviceType?.logoUrl ??
-			FALLBACK_LOGO_UNKNOWN_DEVICE,
-		[formModel.deviceType?.logo, formModel.deviceType?.logoUrl],
-	);
 	const defaultDisplayName = useMemo(
 		() => formModel.deviceType?.name ?? '-',
 		[formModel.deviceType?.name],
@@ -422,7 +415,7 @@ export const DownloadImageDialog: React.FC<DownloadImageDialogProps> = ({
 					<Avatar
 						variant="square"
 						alt={defaultDisplayName}
-						src={logoSrc}
+						src={formModel.deviceType?.logo ?? FALLBACK_LOGO_UNKNOWN_DEVICE}
 						sx={{ mr: 2 }}
 					/>
 					<Typography variant="h5">Add new device</Typography>

--- a/src/components/DownloadImageDialog/models.ts
+++ b/src/components/DownloadImageDialog/models.ts
@@ -97,6 +97,4 @@ export interface DeviceType {
 		| OsSpecificContractInstructions;
 	/** @deprecated */
 	options?: DeviceTypeOptions[];
-	/** @deprecated use DeviceType.logo */
-	logoUrl?: string;
 }

--- a/src/components/DownloadImageDialog/models.ts
+++ b/src/components/DownloadImageDialog/models.ts
@@ -97,11 +97,6 @@ export interface DeviceType {
 		| OsSpecificContractInstructions;
 	/** @deprecated */
 	options?: DeviceTypeOptions[];
-	/** @deprecated */
-	yocto?: {
-		fstype?: string;
-		deployArtifact: string;
-	};
 	/** @deprecated use DeviceType.logo */
 	logoUrl?: string;
 }


### PR DESCRIPTION
Change-type: major
See: https://balena.fibery.io/Work/Project/Stop-using-device-type.json-fields-in-the-UI-791