### PR TITLE
Tabs: Use MUI's `scrollable` variant

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -49,7 +49,7 @@ export const Tabs = ({
 				]}
 				{...boxProps}
 			>
-				<TabList onChange={handleChange}>
+				<TabList onChange={handleChange} variant="scrollable">
 					{tabs.map(({ label, tabProps }, index) => (
 						<Tab label={label} value={index.toString()} {...tabProps} />
 					))}


### PR DESCRIPTION
Tabs: Use MUI's `scrollable` variant

Change-type: minor