### PR TITLE
DownloadImageDialog: Fix downloading the auto-selected release when it has variants

### DIFF
--- a/src/components/DownloadImageDialog/ImageForm.tsx
+++ b/src/components/DownloadImageDialog/ImageForm.tsx
@@ -136,11 +136,14 @@ export const ImageForm = memo(function ImageForm({
 	const handleVersionChange = useCallback(
 		(ver: typeof version) => {
 			if (!ver) {
-				const newVersion =
+				ver =
 					versionSelectionOpts.find((v) => v.isRecommended) ??
 					versionSelectionOpts[0];
-				onChange('version', newVersion?.value);
-				setVersion(newVersion);
+			}
+			if (ver == null) {
+				// This shouldn't really happen, but if it does, that's all we can do.
+				onChange('version', undefined);
+				setVersion(undefined);
 				return;
 			}
 


### PR DESCRIPTION
An extra case that we forgot and used the
stripped version instead of the raw version.

Change-type: patch
See: https://balena.zulipchat.com/#narrow/channel/403752-channel.2Fsupport-help/topic/Orange.20pi.20Zero.20image.20download.20does.20not.20work/near/502224287