### PR TITLE
Fix spinner in action buttons

### DIFF
--- a/src/components/RJST/Actions/Create.tsx
+++ b/src/components/RJST/Actions/Create.tsx
@@ -10,8 +10,7 @@ import { getCreateDisabledReason } from '../utils';
 import { ActionContent, LOADING_DISABLED_REASON } from './ActionContent';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagic } from '@fortawesome/free-solid-svg-icons/faMagic';
-import { Box, Button } from '@mui/material';
-import { Spinner } from '../../Spinner';
+import { Box, Button, CircularProgress } from '@mui/material';
 import { useTranslation } from '../../../hooks/useTranslations';
 import { Tooltip } from '../../Tooltip';
 
@@ -91,12 +90,18 @@ export const Create = <T extends RJSTBaseResource<T>>({
 							}));
 						}}
 					>
-						<Box display="flex" justifyContent="space-between">
+						<Box
+							display="flex"
+							justifyContent="space-between"
+							alignItems="center"
+						>
 							{action.title}
-							<Spinner
-								sx={{ ml: 2 }}
-								show={disabledReason === LOADING_DISABLED_REASON}
-							/>
+							{disabledReason === LOADING_DISABLED_REASON && (
+								<CircularProgress
+									size="1rem"
+									sx={{ ml: 2, color: 'currentcolor' }}
+								/>
+							)}
 						</Box>
 					</ActionContent>
 				</Button>

--- a/src/components/RJST/Actions/Update.tsx
+++ b/src/components/RJST/Actions/Update.tsx
@@ -12,10 +12,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPenToSquare } from '@fortawesome/free-solid-svg-icons/faPenToSquare';
 import type { CheckedState } from '../components/Table/utils';
 import { useTranslation } from '../../../hooks/useTranslations';
-import { Box, Button, useMediaQuery, useTheme } from '@mui/material';
+import {
+	Box,
+	Button,
+	CircularProgress,
+	useMediaQuery,
+	useTheme,
+} from '@mui/material';
 import type { DropDownButtonProps } from '../../DropDownButton';
 import { DropDownButton } from '../../DropDownButton';
-import { Spinner } from '../../Spinner';
 import { Tooltip } from '../../Tooltip';
 
 interface UpdateProps<T extends RJSTBaseResource<T>> {
@@ -101,6 +106,7 @@ export const Update = <T extends RJSTBaseResource<T>>({
 						<Box
 							display="flex"
 							justifyContent="space-between"
+							alignItems="center"
 							gap={2}
 							color={
 								action.isDangerous && !disabledReasonsByAction[action.title]
@@ -109,9 +115,9 @@ export const Update = <T extends RJSTBaseResource<T>>({
 							}
 						>
 							{action.title}
-							<Spinner
-								show={disabledActionReason === LOADING_DISABLED_REASON}
-							/>
+							{disabledActionReason === LOADING_DISABLED_REASON && (
+								<CircularProgress size="1rem" sx={{ color: 'currentcolor' }} />
+							)}
 						</Box>
 					</ActionContent>
 				),
@@ -209,12 +215,18 @@ export const Update = <T extends RJSTBaseResource<T>>({
 								}));
 							}}
 						>
-							<Box display="flex" justifyContent="space-between">
+							<Box
+								display="flex"
+								justifyContent="space-between"
+								alignItems="center"
+							>
 								{action.title}
-								<Spinner
-									sx={{ ml: 2 }}
-									show={disabledUpdateReason === LOADING_DISABLED_REASON}
-								/>
+								{disabledUpdateReason === LOADING_DISABLED_REASON && (
+									<CircularProgress
+										size="1rem"
+										sx={{ ml: 2, color: 'currentcolor' }}
+									/>
+								)}
 							</Box>
 						</ActionContent>
 					</Button>


### PR DESCRIPTION
Fixes a FOUC (flash of unstyled content) on page load for the create and update buttons

Also adapts color to the text content of the button to make sure the spinner is visible

Change-type: patch