### PR TITLE
Fix `Tooltip` not working with `Code` due to not forwarding ref

### DIFF
--- a/src/components/Code/index.tsx
+++ b/src/components/Code/index.tsx
@@ -1,27 +1,33 @@
 import type { TypographyProps } from '@mui/material';
 import { Typography } from '@mui/material';
 import { color } from '@balena/design-tokens';
+import { forwardRef } from 'react';
 
 /**
  * This component will display a text as code.
  */
-export const Code = ({ children, sx, ...props }: TypographyProps) => (
-	<Typography
-		sx={[
-			{
-				background: color.bg.code.value,
-				color: color.text.code.value,
-				borderRadius: 1,
-				px: 1,
-				py: '2px',
-			},
-			// See: https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
-			...(Array.isArray(sx) ? sx : [sx]),
-		]}
-		variant="code"
-		component="code"
-		{...props}
-	>
-		{children}
-	</Typography>
+export const Code = forwardRef<TypographyProps['ref'], TypographyProps>(
+	function Code({ children, sx, ...props }, ref) {
+		return (
+			<Typography
+				sx={[
+					{
+						background: color.bg.code.value,
+						color: color.text.code.value,
+						borderRadius: 1,
+						px: 1,
+						py: '2px',
+					},
+					// See: https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
+					...(Array.isArray(sx) ? sx : [sx]),
+				]}
+				variant="code"
+				component="code"
+				{...props}
+				ref={ref}
+			>
+				{children}
+			</Typography>
+		);
+	},
 );


### PR DESCRIPTION
See: https://mui.com/material-ui/guides/composition/#caveat-with-refs
Change-type: patch