### PR TITLE
Add server-side ordering for tags

### DIFF
--- a/src/components/RJST/Lenses/types/index.ts
+++ b/src/components/RJST/Lenses/types/index.ts
@@ -1,5 +1,8 @@
-import type { RJSTEntityPropertyDefinition } from '../../';
-import type { RJSTContext, RJSTModel } from '../../schemaOps';
+import type {
+	RJSTContext,
+	RJSTEntityPropertyDefinition,
+	RJSTModel,
+} from '../../schemaOps';
 import type {
 	CheckedState,
 	Pagination,
@@ -25,14 +28,14 @@ export interface CollectionLensRendererProps<T extends { id: number }>
 	filtered: T[];
 	selected?: Array<Subset<T>>;
 	checkedState?: CheckedState;
-	sort: TableSortOptions | null;
+	sort: TableSortOptions<T> | null;
 	changeSelected: (
 		selected: T[] | undefined,
 		allChecked?: CheckedState,
 	) => void;
 	data: T[] | undefined;
 	onPageChange?: (page: number, itemsPerPage: number) => void;
-	onSort?: (sort: TableSortOptions) => void;
+	onSort?: (sort: TableSortOptions<T>) => void;
 	pagination: Pagination;
 	rowKey?: keyof T;
 }

--- a/src/components/RJST/Lenses/types/table.tsx
+++ b/src/components/RJST/Lenses/types/table.tsx
@@ -13,7 +13,7 @@ import { useTagActions } from '../../components/Table/useTagActions';
 import { AddTagHandler } from '../../components/Table/AddTagHandler';
 import { Box, styled, Tooltip, Typography } from '@mui/material';
 import { Copy } from '../../../Copy';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import { useAnalyticsContext } from '../../../../contexts/AnalyticsContext';
 import { token } from '../../../../utils/token';
 
@@ -82,7 +82,7 @@ const findTagOfTaggedResource = <T extends object>(
 const sortData = <T extends object>(
 	data: T[],
 	columns: Array<RJSTEntityPropertyDefinition<T>>,
-	sort: TableSortOptions | null,
+	sort: TableSortOptions<T> | null,
 ): T[] => {
 	if (!sort?.field) {
 		return data;
@@ -188,7 +188,7 @@ const TableRenderer = <T extends { id: number }>({
 		if (sort) {
 			return sort;
 		}
-		const sortPreferences = getFromLocalStorage<TableSortOptions>(
+		const sortPreferences = getFromLocalStorage<TableSortOptions<T>>(
 			`${model.resource}__sort`,
 		);
 
@@ -197,7 +197,7 @@ const TableRenderer = <T extends { id: number }>({
 			({
 				direction: 'asc',
 				...columns[0],
-			} as TableSortOptions);
+			} as TableSortOptions<T>);
 
 		onSort?.(sortPref);
 
@@ -209,6 +209,7 @@ const TableRenderer = <T extends { id: number }>({
 			setShowAddTagDialog(false);
 			return;
 		}
+
 		const additionalColumns = selectedTagColumns.map(
 			(key: string, index: number) => {
 				const field = rjstContext.tagField;

--- a/src/components/RJST/Lenses/types/table.tsx
+++ b/src/components/RJST/Lenses/types/table.tsx
@@ -211,14 +211,17 @@ const TableRenderer = <T extends { id: number }>({
 		}
 		const additionalColumns = selectedTagColumns.map(
 			(key: string, index: number) => {
+				const field = rjstContext.tagField;
 				return {
 					title: key,
 					label: `Tag: ${key}`,
 					key: `${TAG_COLUMN_PREFIX}${key}`,
 					selected: true,
 					type: 'predefined',
-					field: rjstContext.tagField,
-					sortable: pagination.serverSide ? false : true,
+					field,
+					sortable: pagination.serverSide
+						? `${field}(tag_key='${key}')/value`
+						: true,
 					index: index + 1 + columns.length,
 					priority: '',
 					render: tagKeyRender(key),

--- a/src/components/RJST/components/Table/AddTagHandler.tsx
+++ b/src/components/RJST/components/Table/AddTagHandler.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from '../../../../hooks/useTranslations';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import { DialogWithCloseButton } from '../../../DialogWithCloseButton';
 import {
 	Button,

--- a/src/components/RJST/components/Table/TableActions.tsx
+++ b/src/components/RJST/components/Table/TableActions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCog, faGripVertical } from '@fortawesome/free-solid-svg-icons';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import type { MenuItemProps } from '@mui/material';
 import {
 	Button,

--- a/src/components/RJST/components/Table/TableCell.tsx
+++ b/src/components/RJST/components/Table/TableCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import { Link } from '@mui/material';
 
 export interface TableCellProps<T> {

--- a/src/components/RJST/components/Table/TableHeader.tsx
+++ b/src/components/RJST/components/Table/TableHeader.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 import { visuallyHidden } from '@mui/utils';
 import type { CheckedState, Order } from './utils';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import {
 	Box,
 	Checkbox,

--- a/src/components/RJST/components/Table/TableRow.tsx
+++ b/src/components/RJST/components/Table/TableRow.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 import type { CheckedState } from './utils';
 import { TableCell, type TableCellProps } from './TableCell';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import {
 	TableCell as MaterialTableCell,
 	TableRow as MaterialTableRow,

--- a/src/components/RJST/components/Table/TableToolbar.tsx
+++ b/src/components/RJST/components/Table/TableToolbar.tsx
@@ -1,6 +1,6 @@
 import type { MenuItemProps } from '@mui/material';
 import { Stack, Typography } from '@mui/material';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import { TableActions } from './TableActions';
 import { token } from '../../../../utils/token';
 import type { ColumnPreferencesChangeProp } from './index';

--- a/src/components/RJST/components/Table/index.tsx
+++ b/src/components/RJST/components/Table/index.tsx
@@ -13,10 +13,11 @@ import {
 	TableBody,
 	TablePagination,
 } from '@mui/material';
-import type { RJSTEntityPropertyDefinition } from '../..';
+
 import { useAnalyticsContext } from '../../../../contexts/AnalyticsContext';
 import { DEFAULT_ITEMS_PER_PAGE } from '../../utils';
 import { token } from '../../../../utils/token';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 
 const StyledMaterialTable = styled(MaterialTable)(() => ({
 	'& [data-table="table_cell__sticky"]': {
@@ -44,10 +45,10 @@ interface TableProps<T> {
 	checkedState?: CheckedState;
 	columns: Array<RJSTEntityPropertyDefinition<T>>;
 	pagination: Pagination;
-	sort: TableSortOptions;
+	sort: TableSortOptions<T>;
 	actions?: MenuItemProps[];
 	onCheck?: (selected: T[] | undefined, allChecked?: CheckedState) => void;
-	onSort?: (sort: TableSortOptions) => void;
+	onSort?: (sort: TableSortOptions<T>) => void;
 	getRowHref: ((entry: any) => string) | undefined;
 	onRowClick?: (entity: T, event: React.MouseEvent<HTMLAnchorElement>) => void;
 	onPageChange?: (page: number, itemsPerPage: number) => void;
@@ -132,7 +133,7 @@ export const Table = <T extends object>({
 			const newOrder = isAsc ? 'desc' : 'asc';
 			// Passing the entire column is not possible because the label might be an HTML element.
 			// This can cause errors when attempting to save it to localStorage.
-			const sortObj: TableSortOptions = {
+			const sortObj: TableSortOptions<T> = {
 				direction: newOrder,
 				field: field,
 				sortable,

--- a/src/components/RJST/components/Table/index.tsx
+++ b/src/components/RJST/components/Table/index.tsx
@@ -123,7 +123,7 @@ export const Table = <T extends object>({
 	const handleOnSort = React.useCallback(
 		(
 			_event: React.MouseEvent<HTMLSpanElement>,
-			{ key, field, refScheme }: RJSTEntityPropertyDefinition<T>,
+			{ key, field, refScheme, sortable }: RJSTEntityPropertyDefinition<T>,
 		) => {
 			if (!sort) {
 				return;
@@ -135,6 +135,7 @@ export const Table = <T extends object>({
 			const sortObj: TableSortOptions = {
 				direction: newOrder,
 				field: field,
+				sortable,
 				key: key,
 				refScheme: refScheme,
 			};

--- a/src/components/RJST/components/Table/useColumns.ts
+++ b/src/components/RJST/components/Table/useColumns.ts
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useState, useEffect } from 'react';
 import type { TagField } from './utils';
-import type { RJSTEntityPropertyDefinition } from '../..';
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
 import { getFromLocalStorage, setToLocalStorage } from '../../utils';
 
 export const TAG_COLUMN_PREFIX = 'tag_column_';

--- a/src/components/RJST/components/Table/utils.ts
+++ b/src/components/RJST/components/Table/utils.ts
@@ -6,6 +6,8 @@ export interface TableSortOptions {
 	direction: Order;
 	field: string;
 	key: string;
+	// TODO: improve typing
+	sortable: boolean | ((a: any, b: any) => number) | string;
 	refScheme?: string;
 }
 

--- a/src/components/RJST/components/Table/utils.ts
+++ b/src/components/RJST/components/Table/utils.ts
@@ -1,13 +1,14 @@
+import type { RJSTEntityPropertyDefinition } from '../../schemaOps';
+
 export type Order = 'asc' | 'desc';
 
 export type CheckedState = 'none' | 'some' | 'all';
 
-export interface TableSortOptions {
+export interface TableSortOptions<T> {
 	direction: Order;
 	field: string;
 	key: string;
-	// TODO: improve typing
-	sortable: boolean | ((a: any, b: any) => number) | string;
+	sortable: RJSTEntityPropertyDefinition<T>['sortable'];
 	refScheme?: string;
 }
 

--- a/src/components/RJST/index.tsx
+++ b/src/components/RJST/index.tsx
@@ -8,6 +8,7 @@ import type {
 	RJSTModel,
 	RJSTBaseResource,
 	RJSTRawModel,
+	RJSTEntityPropertyDefinition,
 } from './schemaOps';
 import {
 	getFieldForFormat,
@@ -178,7 +179,7 @@ export const RJST = <T extends RJSTBaseResource<T>>({
 	// TODO: this logic should be moved in the lens/table.tsx.
 	// With the layer refactor we should have a lens.data.renderer should
 	// only handle a onChange event that has all the info. the lens should handle all cases
-	const [sort, setSort] = React.useState<TableSortOptions | null>(null);
+	const [sort, setSort] = React.useState<TableSortOptions<T> | null>(null);
 	const [internalPagination, setInternalPagination] = React.useState<
 		Pick<Pagination, 'currentPage' | 'itemsPerPage'>
 	>({
@@ -205,13 +206,14 @@ export const RJST = <T extends RJSTBaseResource<T>>({
 	const internalOnChange = React.useCallback(
 		(
 			updatedFilters: JSONSchema[],
-			sortInfo: TableSortOptions | null,
+			sortInfo: TableSortOptions<T> | null,
 			page: number,
 			itemsPerPage: number,
 		) => {
 			if (!onChange) {
 				return;
 			}
+
 			const pineFilter = pagination?.serverSide
 				? convertToPineClientFilter([], updatedFilters)
 				: null;
@@ -651,23 +653,6 @@ export {
 	parseDescription,
 	parseDescriptionProperty,
 	generateSchemaFromRefScheme,
-};
-
-export type RJSTEntityPropertyDefinition<T> = {
-	title: string;
-	label: string | JSX.Element;
-	field: Extract<keyof T, string>;
-	key: string;
-	selected: boolean;
-	index: number;
-	sortable: boolean | ((a: T, b: T) => number);
-	render: (
-		value: any,
-		row: T,
-	) => string | number | JSX.Element | null | undefined;
-	type: string;
-	priority: string;
-	refScheme?: string;
 };
 
 const getTitleAndLabel = <T extends object>(

--- a/src/components/RJST/oData/jsonToOData.ts
+++ b/src/components/RJST/oData/jsonToOData.ts
@@ -265,7 +265,9 @@ export const orderbyBuilder = <T>(
 	// The customSort should look like: { user: { owns_items: [{ uuid: 'xx09x0' }] } }
 	// The refScheme will reference the property path, e.g., owns_items[0].uuid.
 	const customOrderByKey =
-		customSort?.[`${field}_${refScheme}`] ?? customSort?.[field];
+		customSort?.[`${field}_${refScheme}`] ??
+		customSort?.[field] ??
+		(typeof sortInfo.sortable === 'string' ? sortInfo.sortable : undefined);
 
 	if (typeof customOrderByKey === 'string') {
 		return [`${customOrderByKey} ${direction}`, `id ${direction}`];

--- a/src/components/RJST/oData/jsonToOData.ts
+++ b/src/components/RJST/oData/jsonToOData.ts
@@ -250,7 +250,7 @@ export const convertToPineClientFilter = (
 };
 
 export const orderbyBuilder = <T>(
-	sortInfo: TableSortOptions | null,
+	sortInfo: TableSortOptions<T> | null,
 	customSort: RJSTContext<T>['customSort'],
 ) => {
 	if (!sortInfo) {

--- a/src/components/RJST/schemaOps.ts
+++ b/src/components/RJST/schemaOps.ts
@@ -47,6 +47,24 @@ export interface RJSTModel<T> {
 	priorities?: Priorities<T>;
 }
 
+export type RJSTEntityPropertyDefinition<T> = {
+	title: string;
+	label: string | JSX.Element;
+	field: Extract<keyof T, string>;
+	key: string;
+	selected: boolean;
+	sortable: boolean | ((a: T, b: T) => number) | string;
+	index: number;
+	render: (
+		value: any,
+		row: T,
+	) => string | number | JSX.Element | null | undefined;
+
+	type: string;
+	priority: string;
+	refScheme?: string;
+};
+
 export interface CustomSchemaDescription {
 	'x-ref-scheme'?: string[];
 	'x-foreign-key-scheme'?: string[];


### PR DESCRIPTION
Depends-on: https://github.com/balena-io-modules/odata-to-abstract-sql/pull/165

Change-type: minor
See: https://balena.fibery.io/Work/Project/Shape--Build-Add-support-for-sorting-on-user-selected-tag-columns-in-the-server-side-paginated-devic-912