### PR TITLE
Add Horizontal Bar Chart component

### DIFF
--- a/src/components/HorizontalBarChart/HorizontalBarChart.stories.tsx
+++ b/src/components/HorizontalBarChart/HorizontalBarChart.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { HorizontalBarChart } from '.';
+
+const meta = {
+	title: 'Components/Charts/Horizontal Bar Chart',
+	component: HorizontalBarChart,
+	tags: ['autodocs'],
+} satisfies Meta<typeof HorizontalBarChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		items: [
+			{
+				color: 'var(--mui-tokens-color-status-warning-value)',
+				count: 100,
+				title: 'Reduced functionality',
+			},
+			{
+				color: 'var(--mui-tokens-color-status-teal-value)',
+				count: 20,
+				title: 'Configuring',
+			},
+			{
+				color: 'var(--mui-tokens-color-status-danger-value)',
+				count: 100,
+				title: 'Disconnected',
+			},
+			{
+				color: 'var(--mui-tokens-color-status-purple-value)',
+				count: 20,
+				title: 'Post provisioning',
+			},
+			{
+				color: 'var(--mui-tokens-color-status-inactive-value)',
+				count: 20,
+				title: 'Inactive',
+			},
+		],
+		resourceLabel: 'device',
+		resourceLabelPlural: 'devices',
+	},
+};

--- a/src/components/HorizontalBarChart/index.tsx
+++ b/src/components/HorizontalBarChart/index.tsx
@@ -1,0 +1,103 @@
+import { Stack, styled, Tooltip, Typography } from '@mui/material';
+import { token } from '../../utils/token';
+import { useTranslation } from '../../hooks/useTranslations';
+import { useMemo } from 'react';
+
+export interface HorizontalBarChartProps {
+	items: Array<{ color: string; title: string; count: number }>;
+	resourceLabel?: string;
+	resourceLabelPlural?: string;
+}
+
+const Bar = styled('div')({
+	width: '100%',
+	height: 24,
+	display: 'flex',
+	borderRadius: token('shape.borderRadius.sm'),
+	overflow: 'hidden',
+	gap: 2,
+});
+
+const BarItem = styled('span')({
+	minWidth: 3,
+});
+
+const Legend = styled('ul')({
+	display: 'inline',
+	listStyle: 'none',
+	padding: 0,
+	margin: 0,
+});
+
+const LegendItem = styled('li')({
+	display: 'inline-flex',
+	marginRight: token('spacing.2'),
+	alignItems: 'center',
+	'&:before': {
+		content: '""',
+		backgroundColor: 'currentColor',
+		borderRadius: '50%',
+		width: '10px',
+		height: '10px',
+		display: 'inline-block',
+		marginRight: token('spacing.1'),
+	},
+});
+
+export const HorizontalBarChart = ({
+	items,
+	resourceLabel,
+	resourceLabelPlural,
+}: HorizontalBarChartProps) => {
+	const { t } = useTranslation();
+	const totalItems = useMemo(
+		() => items.reduce((sum, item) => sum + item.count, 0),
+		[items],
+	);
+	const filteredItems = useMemo(
+		() => items.filter((item) => item.count > 0),
+		[items],
+	);
+	const getTotalResourcesLabel = (count: number) => {
+		if (resourceLabel && resourceLabelPlural) {
+			return t('labels.total_resources', {
+				count,
+				resource: count > 1 ? resourceLabelPlural : resourceLabel,
+			});
+		} else {
+			return count;
+		}
+	};
+
+	return (
+		<Stack sx={{ gap: token('spacing.2') }}>
+			<Bar>
+				{filteredItems.map((item) => (
+					<Tooltip
+						key={item.title}
+						title={`${item.title}: ${getTotalResourcesLabel(item.count)}`}
+					>
+						<BarItem
+							sx={{
+								backgroundColor: item.color,
+								width: `${Math.floor((item.count / totalItems) * 100)}%`,
+							}}
+						/>
+					</Tooltip>
+				))}
+			</Bar>
+
+			<Legend>
+				{filteredItems.map((item) => (
+					<Tooltip key={item.title} title={getTotalResourcesLabel(item.count)}>
+						<LegendItem style={{ color: item.color }}>
+							<Typography variant="bodySm" color={token('color.text.subtle')}>
+								{item.title}
+							</Typography>
+						</LegendItem>
+					</Tooltip>
+				))}
+			</Legend>
+		</Stack>
+	);
+};

--- a/src/hooks/useTranslations.ts
+++ b/src/hooks/useTranslations.ts
@@ -87,6 +87,7 @@ const translationMap = {
 	'labels.views': 'Views',
 	'labels.filter_one': 'Filter',
 	'labels.filter_other': 'Filters',
+	'labels.total_resources': '{{count}} {{resource}}',
 
 	'labels.save_current_view': 'Save current view',
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,7 @@ export { FileWidget } from './components/Form/Widgets/FileWidget';
 export type { OnFileReadParams } from './components/Form/Widgets/FileWidget';
 export { PasswordWidget } from './components/Form/Widgets/PasswordWidget';
 export { SelectWidget } from './components/Form/Widgets/SelectWidget';
+export { HorizontalBarChart } from './components/HorizontalBarChart';
 export { Code } from './components/Code';
 export { CookiesBanner } from './components/CookiesBanner';
 export type { CollapsedListProps } from './components/CollapsedList';


### PR DESCRIPTION
Replaces our current chart without the external dependency

See https://balena.fibery.io/Work/Project/Replace-the-external-library-for-the-horizontal-bar-chart-with-a-SVG-based-solution-1316

Change-type: minor