### PR TITLE
Pin @mui/lab to 6.0.0-beta.24 to avoid installing beta-dev versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@mui/icons-material": "^6.3.1",
-        "@mui/lab": "^6.0.0-beta.22",
+        "@mui/lab": "6.0.0-beta.24",
         "@mui/material": "^6.3.1",
         "@mui/styled-engine-sc": "^6.3.1",
         "@mui/x-data-grid": "^7.23.5",
@@ -2807,15 +2807,16 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.68",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.68.tgz",
-      "integrity": "sha512-F1JMNeLS9Qhjj3wN86JUQYBtJoXyQvknxlzwNl6eS0ZABo1MiohMONj3/WQzYPSXIKC2bS/ZbyBzdHhi2GnEpA==",
+      "version": "5.0.0-beta.69",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.69.tgz",
+      "integrity": "sha512-r2YyGUXpZxj8rLAlbjp1x2BnMERTZ/dMqd9cClKj2OJ7ALAuiv/9X5E9eHfRc9o/dGRuLSMq/WTjREktJVjxVA==",
+      "deprecated": "This package has been replaced by @base-ui-components/react",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@floating-ui/react-dom": "^2.1.1",
-        "@mui/types": "^7.2.20",
-        "@mui/utils": "^6.3.0",
+        "@mui/types": "^7.2.21",
+        "@mui/utils": "^6.4.1",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1"
@@ -2839,9 +2840,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.3.1.tgz",
-      "integrity": "sha512-2OmnEyoHpj5//dJJpMuxOeLItCCHdf99pjMFfUFdBteCunAK9jW+PwEo4mtdGcLs7P+IgZ+85ypd52eY4AigoQ==",
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.4.11.tgz",
+      "integrity": "sha512-CzAQs9CTzlwbsF9ZYB4o4lLwBv1/qNE264NjuYao+ctAXsmlPtYa8RtER4UsUXSMxNN9Qi+aQdYcKl2sUpnmAw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2875,16 +2876,16 @@
       }
     },
     "node_modules/@mui/lab": {
-      "version": "6.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.0-beta.22.tgz",
-      "integrity": "sha512-9nwUfBj+UzoQJOCbqV+JcCSJ74T+gGWrM1FMlXzkahtYUcMN+5Zmh2ArlttW3zv2dZyCzp7K5askcnKF0WzFQg==",
+      "version": "6.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-6.0.0-beta.24.tgz",
+      "integrity": "sha512-Off0rx2065TfGu5Z8E4OduNiVAqE9p9A8N1268hoXOcx7HzARxJsDFLRKvWgpPMqmGEvR8DVaHkcF2N90UB15A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/base": "5.0.0-beta.68",
-        "@mui/system": "^6.3.1",
+        "@mui/base": "5.0.0-beta.69",
+        "@mui/system": "^6.4.1",
         "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.3.1",
+        "@mui/utils": "^6.4.1",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1"
       },
@@ -2898,8 +2899,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material": "^6.3.1",
-        "@mui/material-pigment-css": "^6.3.1",
+        "@mui/material": "^6.4.1",
+        "@mui/material-pigment-css": "^6.4.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2920,16 +2921,16 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.3.1.tgz",
-      "integrity": "sha512-ynG9ayhxgCsHJ/dtDcT1v78/r2GwQyP3E0hPz3GdPRl0uFJz/uUTtI5KFYwadXmbC+Uv3bfB8laZ6+Cpzh03gA==",
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.4.11.tgz",
+      "integrity": "sha512-k2D3FLJS+/qD0qnd6ZlAjGFvaaxe1Dl10NyvpeDzIebMuYdn8VqYe6XBgGueEAtnzSJM4V03VD9kb5Fi24dnTA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.3.1",
-        "@mui/system": "^6.3.1",
-        "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.3.1",
+        "@mui/core-downloads-tracker": "^6.4.11",
+        "@mui/system": "^6.4.11",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -2948,7 +2949,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.3.1",
+        "@mui/material-pigment-css": "^6.4.11",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -2975,13 +2976,13 @@
       "license": "MIT"
     },
     "node_modules/@mui/private-theming": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.3.1.tgz",
-      "integrity": "sha512-g0u7hIUkmXmmrmmf5gdDYv9zdAig0KoxhIQn1JN8IVqApzf/AyRhH3uDGx5mSvs8+a1zb4+0W6LC260SyTTtdQ==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
+      "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.3.1",
+        "@mui/utils": "^6.4.9",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3002,9 +3003,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.3.1.tgz",
-      "integrity": "sha512-/7CC0d2fIeiUxN5kCCwYu4AWUDd9cCTxWCyo0v/Rnv6s8uk6hWgJC3VLZBoDENBHf/KjqDZuYJ2CR+7hD6QYww==",
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.11.tgz",
+      "integrity": "sha512-74AUmlHXaGNbyUqdK/+NwDJOZqgRQw6BcNvhoWYLq3LGbLTkE+khaJ7soz6cIabE4CPYqO2/QAIU1Z/HEjjpcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -3059,16 +3060,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.3.1.tgz",
-      "integrity": "sha512-AwqQ3EAIT2np85ki+N15fF0lFXX1iFPqenCzVOSl3QXKy2eifZeGd9dGtt7pGMoFw5dzW4dRGGzRpLAq9rkl7A==",
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.11.tgz",
+      "integrity": "sha512-gibtsrZEwnDaT5+I/KloOj/yHluX5G8heknuxBpQOdEQ3Gc0avjSImn5hSeKp8D4thiwZiApuggIjZw1dQguUA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.3.1",
-        "@mui/styled-engine": "^6.3.1",
-        "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.3.1",
+        "@mui/private-theming": "^6.4.9",
+        "@mui/styled-engine": "^6.4.11",
+        "@mui/types": "~7.2.24",
+        "@mui/utils": "^6.4.9",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -3099,9 +3100,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.21",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
-      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
+      "version": "7.2.24",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3113,13 +3114,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.3.1.tgz",
-      "integrity": "sha512-sjGjXAngoio6lniQZKJ5zGfjm+LD2wvLwco7FbKe1fu8A7VIFmz2SwkLb+MDPLNX1lE7IscvNNyh1pobtZg2tw==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
+      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.21",
+        "@mui/types": "~7.2.24",
         "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/icons-material": "^6.3.1",
-    "@mui/lab": "^6.0.0-beta.22",
+    "@mui/lab": "6.0.0-beta.24",
     "@mui/material": "^6.3.1",
     "@mui/styled-engine-sc": "^6.3.1",
     "@mui/x-data-grid": "^7.23.5",


### PR DESCRIPTION
Atm installing `^6.0.0-beta.22` results installing `6.0.0-dev.240424162023-9968b4889d` which is actually a lower version than `6.0.0-beta.22` .
Picked this version b/c it's already tested in some other projects.

Change-type: patch
See: https://www.npmjs.com/package/@mui/lab?activeTab=versions
See: [#channel/support-help > ui-shared-component ^6.0.0-beta.22 unexpected results @ 💬](https://balena.zulipchat.com/#narrow/channel/403752-channel.2Fsupport-help/topic/ui-shared-component.20.5E6.2E0.2E0-beta.2E22.20unexpected.20results/near/511464489)