### PR TITLE
RJST Table: Add `onManageColumnsOpen` prop and track clicks

### DIFF
--- a/src/components/RJST/Lenses/types/table.tsx
+++ b/src/components/RJST/Lenses/types/table.tsx
@@ -278,6 +278,11 @@ const TableRenderer = <T extends { id: number }>({
 					});
 				}}
 				actions={actions ?? []}
+				onManageColumnsOpen={() => {
+					analytics.webTracker?.track('Open manage columns', {
+						resource: model.resource,
+					});
+				}}
 			/>
 			{showAddTagDialog && tagKeys?.length && (
 				<AddTagHandler

--- a/src/components/RJST/components/Table/TableActions.tsx
+++ b/src/components/RJST/components/Table/TableActions.tsx
@@ -76,12 +76,14 @@ interface TableActionsProps<T> {
 	columns: Array<RJSTEntityPropertyDefinition<T>>;
 	actions?: MenuItemProps[];
 	onColumnPreferencesChange?: ColumnPreferencesChangeProp<T>;
+	onManageColumnsOpen?: () => void;
 }
 
 export const TableActions = <T extends object>({
 	columns,
 	actions,
 	onColumnPreferencesChange,
+	onManageColumnsOpen,
 }: TableActionsProps<T>) => {
 	const [anchorEl, setAnchorEl] = React.useState<HTMLElement>();
 	const theme = useTheme();
@@ -91,6 +93,7 @@ export const TableActions = <T extends object>({
 
 	const handleClick = (event: React.MouseEvent<HTMLElement>) => {
 		setAnchorEl(event.currentTarget);
+		onManageColumnsOpen?.();
 	};
 	const handleClose = () => {
 		setAnchorEl(undefined);

--- a/src/components/RJST/components/Table/TableToolbar.tsx
+++ b/src/components/RJST/components/Table/TableToolbar.tsx
@@ -9,6 +9,7 @@ interface TableToolbarProps<T> {
 	numSelected?: number;
 	columns: Array<RJSTEntityPropertyDefinition<T>>;
 	actions?: MenuItemProps[];
+	onManageColumnsOpen?: () => void;
 	onColumnPreferencesChange?: ColumnPreferencesChangeProp<T>;
 }
 
@@ -16,6 +17,7 @@ export const TableToolbar = <T extends object>({
 	numSelected = 0,
 	columns,
 	actions,
+	onManageColumnsOpen,
 	onColumnPreferencesChange,
 }: TableToolbarProps<T>) => {
 	return (
@@ -41,6 +43,7 @@ export const TableToolbar = <T extends object>({
 				columns={columns}
 				actions={actions}
 				onColumnPreferencesChange={onColumnPreferencesChange}
+				onManageColumnsOpen={onManageColumnsOpen}
 			/>
 		</Stack>
 	);

--- a/src/components/RJST/components/Table/index.tsx
+++ b/src/components/RJST/components/Table/index.tsx
@@ -53,6 +53,7 @@ interface TableProps<T> {
 	onRowClick?: (entity: T, event: React.MouseEvent<HTMLAnchorElement>) => void;
 	onPageChange?: (page: number, itemsPerPage: number) => void;
 	onColumnPreferencesChange?: ColumnPreferencesChangeProp<T>;
+	onManageColumnsOpen?: () => void;
 }
 
 export const Table = <T extends object>({
@@ -62,6 +63,7 @@ export const Table = <T extends object>({
 	checkedState,
 	columns,
 	pagination,
+	onManageColumnsOpen,
 	sort,
 	actions,
 	onCheck,
@@ -211,6 +213,7 @@ export const Table = <T extends object>({
 				columns={columns}
 				actions={actions}
 				onColumnPreferencesChange={onColumnPreferencesChange}
+				onManageColumnsOpen={onManageColumnsOpen}
 			/>
 			<TableContainer sx={{ maxHeight: '70vh' }}>
 				<StyledMaterialTable stickyHeader>


### PR DESCRIPTION
Fibery: https://balena.fibery.io/Work/Improvement/Track-clicks-on-the-Manage-columns-action-2746
Change-type: minor