### PR TITLE
Experiment: RJST: Add `useExperimentalReducedColumnLocalStorageKeyPrefix`

### DIFF
--- a/src/components/RJST/Lenses/types/index.ts
+++ b/src/components/RJST/Lenses/types/index.ts
@@ -38,4 +38,5 @@ export interface CollectionLensRendererProps<T extends { id: number }>
 	onSort?: (sort: TableSortOptions<T>) => void;
 	pagination: Pagination;
 	rowKey?: keyof T;
+	useExperimentalReducedColumnLocalStorageKeyPrefix?: boolean;
 }

--- a/src/components/RJST/Lenses/types/table.tsx
+++ b/src/components/RJST/Lenses/types/table.tsx
@@ -156,12 +156,14 @@ const TableRenderer = <T extends { id: number }>({
 	model,
 	sort,
 	rowKey = 'id',
+	useExperimentalReducedColumnLocalStorageKeyPrefix,
 }: CollectionLensRendererProps<T>) => {
 	const { state: analytics } = useAnalyticsContext();
 	const [columns, setColumns] = useColumns<T>(
 		rjstContext.resource,
 		properties,
 		tagKeyRender,
+		useExperimentalReducedColumnLocalStorageKeyPrefix,
 	);
 
 	const { actions, showAddTagDialog, setShowAddTagDialog, tagKeys } =

--- a/src/components/RJST/index.tsx
+++ b/src/components/RJST/index.tsx
@@ -134,6 +134,7 @@ export interface RJSTProps<T> extends Omit<BoxProps, 'onChange'> {
 	rowKey?: keyof T;
 	noDataInfo?: NoDataInfo;
 	persistFilters?: boolean;
+	useExperimentalReducedColumnLocalStorageKeyPrefix?: boolean;
 }
 
 // TODO: Refactor into multiple layers: one for handling
@@ -158,6 +159,7 @@ export const RJST = <T extends RJSTBaseResource<T>>({
 	rowKey,
 	noDataInfo,
 	persistFilters = true,
+	useExperimentalReducedColumnLocalStorageKeyPrefix,
 	...boxProps
 }: RJSTProps<T>) => {
 	const { t } = useTranslation();
@@ -619,6 +621,9 @@ export const RJST = <T extends RJSTBaseResource<T>>({
 								{ ...(pagination ?? {}), ...internalPagination } as Pagination
 							}
 							rowKey={rowKey}
+							useExperimentalReducedColumnLocalStorageKeyPrefix={
+								useExperimentalReducedColumnLocalStorageKeyPrefix
+							}
 						/>
 					)}
 


### PR DESCRIPTION
Change-type: patch
Fibery: https://balena.fibery.io/Work/Improvement/Reduce-the-number-of-columns-that-are-visible-by-default-on-the-devices-table-2725