### PR TITLE
RJST helpers: Deprecate rjstGetModelForCollection in favor of `rjstGetModelForCollection2`

### DIFF
--- a/src/components/RJST/RJST.stories.tsx
+++ b/src/components/RJST/RJST.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import type { RJSTRawModel } from '.';
 import {
 	RJST,
-	rjstGetModelForCollection,
+	rjstGetModelForCollection2 as rjstGetModelForCollection,
 	rjstRunTransformers,
 	type RJSTProps,
 } from '.';
@@ -87,7 +87,10 @@ const SimpleRjstTemplate = ({
 }: Omit<RJSTProps<any>, 'model'>) => {
 	const queryClient = new QueryClient();
 	const memoizedModel = React.useMemo(() => {
-		return rjstGetModelForCollection(demoModel);
+		return rjstGetModelForCollection(
+			demoModel,
+			demoModel.permissions['default'],
+		);
 	}, []);
 
 	const memoizedData = React.useMemo(() => {

--- a/src/components/RJST/index.tsx
+++ b/src/components/RJST/index.tsx
@@ -33,6 +33,7 @@ import { Create } from './Actions/Create';
 import {
 	rjstDefaultPermissions,
 	rjstGetModelForCollection,
+	rjstGetModelForCollection2,
 	rjstRunTransformers,
 } from './models/helpers';
 import {
@@ -640,6 +641,7 @@ export {
 	rjstRunTransformers,
 	rjstDefaultPermissions,
 	rjstGetModelForCollection,
+	rjstGetModelForCollection2,
 	rjstAddToSchema,
 	type RJSTAction,
 	type RJSTBaseResource,

--- a/src/components/RJST/models/helpers.ts
+++ b/src/components/RJST/models/helpers.ts
@@ -55,6 +55,8 @@ export const rjstRunTransformers = <
 	return mutatedData;
 };
 
+// TODO: Drop me in the next major
+/** @deprecated This function will be removed in the next major. Use rjstGetModelForCollection2 instead */
 // This transformation would happen elsewhere, and it wouldn't be part of RJST
 export const rjstGetModelForCollection = <T>(
 	model: RJSTRawModel<T>,

--- a/src/components/RJST/models/helpers.ts
+++ b/src/components/RJST/models/helpers.ts
@@ -1,5 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
-import type { RJSTModel, RJSTRawModel } from '../schemaOps';
+import type { Permissions, RJSTModel, RJSTRawModel } from '../schemaOps';
 import { rjstJsonSchemaPick } from '../schemaOps';
 
 type Transformers<
@@ -73,6 +73,25 @@ export const rjstGetModelForCollection = <T>(
 		permissions:
 			(accessRole != null && model.permissions[accessRole]) ||
 			model.permissions['default'],
+		schema,
+	};
+};
+
+// This transformation would happen elsewhere, and it wouldn't be part of RJST
+export const rjstGetModelForCollection2 = <T>(
+	model: RJSTRawModel<T>,
+	permissions: Permissions<T>,
+): RJSTModel<T> => {
+	const schema = model.priorities
+		? rjstJsonSchemaPick(model.schema, [
+				...model.priorities.primary,
+				...model.priorities.secondary,
+				...model.priorities.tertiary,
+			])
+		: model.schema;
+	return {
+		...model,
+		permissions,
 		schema,
 	};
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -117,6 +117,7 @@ export {
 	rjstRunTransformers,
 	rjstDefaultPermissions,
 	rjstGetModelForCollection,
+	rjstGetModelForCollection2,
 	rjstAddToSchema,
 	type RJSTAction,
 	type RJSTBaseResource,


### PR DESCRIPTION
Change-type: minor
Fibery: https://balena.fibery.io/Work/Project/Change-Membership-Role-Permissions-to-not-have-inheritance-in-the-UI-1393
Connects-to: https://github.com/balena-io/balena-ui/pull/7126