### PR TITLE
Disable interactivity on all tooltips

### DIFF
--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1024,6 +1024,7 @@ export const theme = createTheme({
 		MuiTooltip: {
 			defaultProps: {
 				arrow: true,
+				disableInteractive: true,
 			},
 			styleOverrides: {
 				tooltip: {


### PR DESCRIPTION
Tooltips will now close when the user hovers over it

Change-type: patch